### PR TITLE
Add DeFi Monitoring Proposal

### DIFF
--- a/submissions/defi/hendraaragaki-monitoring.md
+++ b/submissions/defi/hendraaragaki-monitoring.md
@@ -1,0 +1,25 @@
+# Project Proposal: DeFi Monitoring Dashboard
+
+## Author
+- GitHub: @hendraaragaki
+
+## Category
+- defi (Finance, trading, payments)
+
+## Project Overview
+The **DeFi Monitoring Dashboard** is a simple application designed to track on-chain transactions, liquidity pools, and protocol activities in real-time.  
+Its purpose is to help users better understand asset flows within decentralized finance by providing clear and easy-to-read visualizations.
+
+## Features
+- On-chain transaction monitoring  
+- Liquidity pool tracking  
+- Simple alerts for significant changes  
+- Lightweight and mobile-friendly dashboard  
+
+## Benefits
+- Provides transparency into DeFi protocol activities  
+- Helps users understand DeFi trends and asset movements  
+- Can be extended with analytics and integrations in the future  
+
+## Status
+Initial proposal – contribution for the Soundness Testnet vApps.


### PR DESCRIPTION
This PR adds a new proposal for a simple DeFi Monitoring Dashboard under submissions/defi.