### PR TITLE
Add zk-Automation Bot Idea for Proof of Personhood (by Heave99)

### DIFF
--- a/submissions/infrastructure/Heave99.md
+++ b/submissions/infrastructure/Heave99.md
@@ -1,0 +1,26 @@
+# Project Idea: zk-Automation Bot for Proof of Personhood
+
+## 👤 Developer
+- **Name**: Ilham Ramadhani  
+- **Discord**: @ilhamrd9999  
+- **GitHub**: https://github.com/Heave99  
+
+## ⚡ Proof System
+- SP1  
+- Risc0  
+
+## 📝 Description
+Building a **zk-powered automation bot** for Web3 tasks.  
+The bot interacts with dApps and protocols while using **Soundness Layer attestations** for verifiable actions, such as:  
+- Auto-claim reward bots with zk-proof verification  
+- zk-attestations for **Proof of Personhood** and identity credentials  
+- Future integration into **zkGames** or private governance tools  
+
+## 🎯 Goal
+- Showcase **chain-agnostic attestations** in real-world automation tools  
+- Provide **trustless & verifiable actions** for end-users  
+- Contribute feedback and test scenarios for Soundness CLI & attestation layer  
+
+## 🔗 Links
+- GitHub profile: [https://github.com/Heave99](https://github.com/Heave99)  
+- Active participation in testnets: 0G, Momentum, Anoma, Humanity Protocol, Fraction AI


### PR DESCRIPTION
This PR adds a new project idea: **zk-Automation Bot for Proof of Personhood**.

- 👤 Developer: Ilham Ramadhani (@lhamr3199 on Discord)  
- 🔗 GitHub: https://github.com/Heave99  
- ⚡ Proof systems: SP1, Risc0  

### Overview
A zk-powered automation bot that leverages **Soundness Layer attestations** for verifiable actions in Web3, such as:
- Auto-claim reward bots with zk-proof verification
- zk-attestations for identity credentials / Proof of Personhood
- Future extensions into zkGames & private governance

**Goal:** Showcase chain-agnostic attestations in real automation tools, provide trustless & verifiable actions, and contribute feedback for Soundness CLI.