### PR TITLE
feat: add zkProof-Visualizer vApp proposal (observability dashboard)

### DIFF
--- a/submissions/infrastructure/zkProof-Visualizer.md
+++ b/submissions/infrastructure/zkProof-Visualizer.md
@@ -1,0 +1,47 @@
+# zkProof-Visualizer
+
+## Category
+infrastructure
+
+## Name
+zkProof-Visualizer
+
+## Author
+@seu-github-username
+
+## Discord ID
+seu-discord-id
+
+## Idea
+A vApp focused on **observability and monitoring** of zkProofs in the Soundness testnet.  
+It provides a **real-time dashboard** to visualize the lifecycle of proofs:  
+- **Generation** → proofs being created by applications  
+- **Submission** → proofs uploaded to Walrus  
+- **Verification** → attestations performed by Soundness Layer  
+
+This vApp makes the invisible process of proof verification **visible and trackable**, helping both developers and the community understand performance and trust guarantees.
+
+## Why
+- Developers need **real-time insights** to debug and optimize.  
+- The community benefits from **transparent proof metrics**.  
+- Adds value to the **infrastructure category**, complementing dApps and identity/DeFi use cases.
+
+## Architecture
+- **Frontend:** React + Chart.js → renders interactive graphs (proofs per second, verification latency, storage success).  
+- **Backend:** Node.js service parsing logs from the Soundness CLI and exposing a REST/GraphQL API.  
+- **Integration:**  
+  - Discord bot with `/monitor-vapp` command showing summary stats.  
+  - Dockerized for easy deployment.  
+
+## Timeline
+- **Week 1-2:** Build backend log parser + API.  
+- **Week 3-4:** Develop React dashboard with proof lifecycle visualization.  
+- **Week 5:** Add Discord integration + polish UI.  
+
+## Vision
+This vApp will become the **go-to monitoring tool** for developers and validators in the Soundness ecosystem, turning proof generation into a transparent and accessible process.
+
+---
+
+*"From proofs in the dark, to proofs in the dashboard."*
+

--- a/submissions/infrastructure/zkProof-Visualizer.md
+++ b/submissions/infrastructure/zkProof-Visualizer.md
@@ -7,10 +7,10 @@ infrastructure
 zkProof-Visualizer
 
 ## Author
-@seu-github-username
+@MatheusSntsLopes
 
 ## Discord ID
-seu-discord-id
+820641826738405429
 
 ## Idea
 A vApp focused on **observability and monitoring** of zkProofs in the Soundness testnet.  

--- a/submissions/infrastructure/zkProof-Visualizer.md
+++ b/submissions/infrastructure/zkProof-Visualizer.md
@@ -13,35 +13,39 @@ zkProof-Visualizer
 820641826738405429
 
 ## Idea
-A vApp focused on **observability and monitoring** of zkProofs in the Soundness testnet.  
-It provides a **real-time dashboard** to visualize the lifecycle of proofs:  
-- **Generation** → proofs being created by applications  
-- **Submission** → proofs uploaded to Walrus  
-- **Verification** → attestations performed by Soundness Layer  
+# zkProof-Visualizer
 
-This vApp makes the invisible process of proof verification **visible and trackable**, helping both developers and the community understand performance and trust guarantees.
+## Overview
+The **zkProof-Visualizer** is a real-time dashboard that transforms the process of generating, verifying, and storing zk-proofs into a clear, transparent, and accessible experience.  
 
-## Why
-- Developers need **real-time insights** to debug and optimize.  
-- The community benefits from **transparent proof metrics**.  
-- Adds value to the **infrastructure category**, complementing dApps and identity/DeFi use cases.
-
-## Architecture
-- **Frontend:** React + Chart.js → renders interactive graphs (proofs per second, verification latency, storage success).  
-- **Backend:** Node.js service parsing logs from the Soundness CLI and exposing a REST/GraphQL API.  
-- **Integration:**  
-  - Discord bot with `/monitor-vapp` command showing summary stats.  
-  - Dockerized for easy deployment.  
-
-## Timeline
-- **Week 1-2:** Build backend log parser + API.  
-- **Week 3-4:** Develop React dashboard with proof lifecycle visualization.  
-- **Week 5:** Add Discord integration + polish UI.  
-
-## Vision
-This vApp will become the **go-to monitoring tool** for developers and validators in the Soundness ecosystem, turning proof generation into a transparent and accessible process.
+By providing observability into the entire proof lifecycle, this vApp enhances trust, performance monitoring, and community transparency.
 
 ---
 
-*"From proofs in the dark, to proofs in the dashboard."*
+## Motivation
+- The community benefits from **transparent proof metrics**.
+- Adds value to the **infrastructure category**, complementing dApps and identity/DeFi use cases.
+- Bridges the gap between **proof generation** and **developer insights**.
 
+---
+
+## Architecture
+- **Frontend:** React + Chart.js → renders interactive graphs (proofs per second, verification latency, storage).
+- **Backend:** Node.js service parsing logs from the Soundness CLI and exposing a REST/GraphQL API.
+- **Integration:**
+  - Discord bot with `/monitor-vapp` command showing summary stats.
+  - Dockerized for easy deployment.
+
+---
+
+## Timeline
+- **Week 1–2:** Build backend log parser + API.
+- **Week 3–4:** Develop React dashboard with proof lifecycle visualization.
+- **Week 5:** Add Discord integration + polish UI.
+
+---
+
+## Vision
+This vApp will become the **go-to monitoring tool** for developers and validators in the Soundness ecosystem, ensuring every proof is visible and every process measurable.  
+
+*"From proofs in the dark, to proofs in the dashboard."*


### PR DESCRIPTION
This PR adds a new vApp proposal under `infrastructure`: **zkProof-Visualizer**.

- Real-time dashboard for zk proof lifecycle:
  - generation → submission to Walrus → attestation on Soundness
- Frontend (React + Chart.js), Backend (Node.js parser + REST/GraphQL)
- Discord integration with `/monitor-vapp` for quick stats
- Dockerized for easy deployment

Why:
- Improves observability for devs and validators
- Public, transparent proof metrics for the community
- Complements the infrastructure category with monitoring tooling

Timeline:
- W1–2: backend parser + API
- W3–4: React dashboard
- W5: Discord integration + UX polish
