### PR TITLE
Add vApp proposal: NFT Time Capsule

### DIFF
--- a/submissions/gaming/0xZepeto.md
+++ b/submissions/gaming/0xZepeto.md
@@ -1,0 +1,30 @@
+# vApp Proposal
+
+## Name
+NFT Time Capsule
+
+## Description
+NFT Time Capsule is a unique NFT application where the content can only be unlocked after a specific time.  
+Users can mint an NFT that contains a hidden message, artwork, or reward, and define a release date.  
+The Soundness Layer is used to verify the timestamp and generate proofs for unlocking the content.
+
+## Category
+NFT
+
+## Key Features
+- Create NFTs with locked content (text, image, or file).
+- Define a future release time (e.g., one year later).
+- Use Soundness proofs to validate the release timestamp.
+- Unlock content only after the defined date.
+
+## Benefits
+- Perfect for digital gifts and surprises (e.g., birthdays, anniversaries).
+- Store secret messages or memories for the future.
+- Make NFTs more interactive and meaningful.
+- Adds a creative and practical use case for Web3 NFTs.
+
+## Target Users
+- NFT collectors
+- Digital artists
+- Web3 communities
+- Users who want unique and time-based NFT experiences


### PR DESCRIPTION
This PR adds my vApp proposal under the Gaming category.

Name: NFT Time Capsule  
Description: NFT Time Capsule is a unique NFT application where the content can only be unlocked after a specific time. Users can mint an NFT that contains a hidden message, artwork, or reward, and define a release date. This brings a new way to gamify experiences and create suspense in NFT collections.
