### PR TITLE
Add zkVerified Gaming Leaderboard proposal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "testnet-vapps",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "testnet-vapps",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/submissions/gaming/zidr1.md
+++ b/submissions/gaming/zidr1.md
@@ -1,0 +1,40 @@
+# zkVerified Gaming Leaderboard
+
+## Overview
+A decentralized gaming leaderboard that uses the Soundness Layer to ensure fair play by validating player scores with zero-knowledge proofs (zkProofs).  
+This ensures that all scores submitted are genuine, verifiable, and cannot be manipulated, while preserving the privacy of player data.
+
+## Problem Statement
+Traditional leaderboards are vulnerable to manipulation (e.g., bots, hacked clients, or falsified score submissions).  
+Players and communities need a trustless way to validate scores without central authority or exposing sensitive gameplay data.
+
+## Proposed Solution
+- Integrate Soundness Layer as a verification engine.
+- Players generate a zkProof of their score completion when submitting results.
+- The leaderboard only accepts scores accompanied by valid zkProofs.
+- Privacy is preserved: proof shows validity without revealing raw game data.
+
+## Technical Architecture
+- **Game Client (frontend)**: Provides score data and generates zkProof of completion.
+- **Proof Generator (backend or local)**: Uses Soundness SDK to create zkProofs.
+- **Verifier (on-chain)**: Smart contract integrated with Soundness Layer verifies proofs before updating the leaderboard.
+- **Leaderboard dApp (frontend)**: Displays only verified scores.
+
+## Development Timeline
+- **Week 1**: Define game mechanics + minimal scoring system.
+- **Week 2**: Implement zkProof generation using Soundness SDK.
+- **Week 3**: Build smart contract verifier + leaderboard UI.
+- **Week 4**: Deploy prototype to testnet and collect feedback.
+
+## Team / Contributors
+- GitHub: [@zidr1](https://github.com/zidr1)
+- Username Discord: mogaelig#0
+- User ID  Discord: (862107794253676545)
+
+## Category
+Gaming
+
+## Future Extensions
+- Expand to multiplayer competitions.
+- On-chain tournaments with verified rewards.
+- Integration with NFT-based player identities.

--- a/submissions/gaming/zidr1.md
+++ b/submissions/gaming/zidr1.md
@@ -13,12 +13,15 @@ Players and communities need a trustless way to validate scores without central 
 - Players generate a zkProof of their score completion when submitting results.
 - The leaderboard only accepts scores accompanied by valid zkProofs.
 - Privacy is preserved: proof shows validity without revealing raw game data.
+- **Example Use Case**: simple games like Flappy Bird or 2048 where players submit scores, and only valid zkProof-backed results are accepted.
 
 ## Technical Architecture
 - **Game Client (frontend)**: Provides score data and generates zkProof of completion.
 - **Proof Generator (backend or local)**: Uses Soundness SDK to create zkProofs.
 - **Verifier (on-chain)**: Smart contract integrated with Soundness Layer verifies proofs before updating the leaderboard.
 - **Leaderboard dApp (frontend)**: Displays only verified scores.
+
+📂 Repo (WIP): [zk-gaming-leaderboard](https://github.com/zidr1/zk-gaming-leaderboard)
 
 ## Development Timeline
 - **Week 1**: Define game mechanics + minimal scoring system.
@@ -29,7 +32,7 @@ Players and communities need a trustless way to validate scores without central 
 ## Team / Contributors
 - GitHub: [@zidr1](https://github.com/zidr1)
 - Username Discord: mogaelig#0
-- User ID  Discord: (862107794253676545)
+- User ID Discord: (862107794253676545)
 
 ## Category
 Gaming
@@ -38,3 +41,4 @@ Gaming
 - Expand to multiplayer competitions.
 - On-chain tournaments with verified rewards.
 - Integration with NFT-based player identities.
+- Cross-game universal leaderboard for Web3 gaming.


### PR DESCRIPTION
This PR adds my submission for the zkVerified Gaming Leaderboard idea under the Gaming category.  
The proposal describes a decentralized gaming leaderboard that leverages zero-knowledge proofs to verify scores, ensuring fairness and transparency for players.  
