### PR TITLE
Add vApp proposal: Proof-of-Skill Gaming Reputation

### DIFF
--- a/submissions/gaming/bancroftvanrug.md
+++ b/submissions/gaming/bancroftvanrug.md
@@ -1,0 +1,79 @@
+# vApp Submission: Proof-of-Skill Gaming Reputation
+
+## Verification
+```yaml
+github_username: "Bancroftvanrug"
+discord_id: "1225880850697289851"
+timestamp: "2025-09-01"
+```
+
+## Developer
+- **Name**: Bancroft Vanrug  
+- **GitHub**: @Bancroftvanrug  
+- **Discord**: 1225880850697289851  
+- **Experience**: Web3 developer exploring zkApps, decentralized identity, and gaming integrations.
+
+## Project
+
+### Name & Category
+- **Project**: Proof-of-Skill Gaming Reputation  
+- **Category**: gaming (with elements of identity)
+
+### Description
+Most Web3 gaming apps focus on assets (NFTs, tokens) but ignore **player skill**.  
+This vApp creates a **skill-based reputation system** where players can prove they completed in-game challenges (speedruns, puzzles, strategy) using **zero-knowledge proofs**, without revealing how they solved them.  
+
+Players build a verifiable, portable skill reputation across multiple games.
+
+### SL Integration  
+- Use **Soundness Layer** to verify zkProofs of challenge completion.  
+- Store player reputation in a zkApp, making it portable across games.  
+- Integrate with `soundness-cli` for proof submission and validation on the testnet.  
+
+## Technical
+
+### Architecture
+1. Game generates challenge data → player attempts solution.  
+2. Solution converted into zkProof (valid/invalid).  
+3. Proof submitted via Soundness Layer.  
+4. Reputation score updated in zkApp (on-chain).  
+5. vApp frontend shows player reputation dashboard.  
+
+### Stack
+- **Frontend**: React + Tailwind (dashboard for reputation)  
+- **Backend**: Node.js (API & proof relay)  
+- **Blockchain**: Soundness Layer testnet zkApp  
+- **Storage**: WALRUS/IPFS for challenge metadata  
+
+### Features
+1. **Skill Proofs** – players prove challenge completion with zkProofs.  
+2. **Reputation Dashboard** – portable reputation across games.  
+3. **Fair Matchmaking** – skill-based ranking system, anti-cheat enabled.  
+
+## Timeline
+
+### PoC (2-4 weeks)
+- [ ] Define simple challenge (e.g., puzzle/quiz).  
+- [ ] Generate proof circuit and integrate with Soundness Layer.  
+- [ ] Basic dashboard to show proof submissions.  
+
+### MVP (4-8 weeks)  
+- [ ] Expand to multiple challenge types.  
+- [ ] Reputation scoring system.  
+- [ ] Cross-game integration demo.  
+- [ ] User testing in community.  
+
+## Innovation
+- **Not just NFTs** – focuses on skill, not only assets.  
+- **Privacy-preserving** – players prove ability without revealing strategies.  
+- **Interoperable reputation** – one skill profile across many games.  
+
+## Contact
+- Discord DM: 1225880850697289851  
+- GitHub Issues/PR updates  
+
+**Checklist before submitting:**
+- [x] All fields completed  
+- [x] GitHub username matches PR author  
+- [x] SL integration explained  
+- [x] Timeline is realistic  


### PR DESCRIPTION
This PR adds a new vApp proposal under the gaming category.

## Project
- **Name**: Proof-of-Skill Gaming Reputation
- **Category**: Gaming (with Identity aspects)
- **Author**: @Bancroftvanrug
- **Discord ID**: 1225880850697289851

## Features
- Skill proofs using zkProofs
- Portable skill-based reputation dashboard
- Fair matchmaking & anti-cheat system

## Soundness Layer Integration
- Uses soundness-cli for proof submission
- Reputation stored in zkApp on SL testnet
