### PR TITLE
This PR adds a vApp proposal submission for the Soundness Layer Testnet.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "testnet-vapps",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "testnet-vapps",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/submissions/identity/KikachukwuClarence.md
+++ b/submissions/identity/KikachukwuClarence.md
@@ -1,0 +1,82 @@
+# vApp Submission: Uname-Soundness Identity Bridge
+
+## Verification
+```yaml
+github_username: "KikachukwuClarence"
+discord_id: "kikachukwuclarence"
+timestamp: "2025-08-31"
+Developer
+
+Name: Kikachukwu Clarence
+
+GitHub: @KikachukwuClarence
+
+Discord: kikachukwuclarence
+
+X: @kikachukwuc
+
+Experience: Web3 researcher and community builder interested in interoperability and zero-knowledge systems.
+
+
+Project
+
+Name & Category
+
+Project: Uname-Soundness Identity Bridge
+
+Category: identity / defi
+
+
+Description
+
+This vApp integrates Uname (Union’s universal identity system) with Soundness Layer’s zero-knowledge validation.
+The goal is to give users a portable, privacy-preserving identity they can use for testnet participation, rewards, and cross-chain apps.
+
+SL Integration
+
+Verify Uname ownership using Soundness Layer zk proofs
+
+Validate user actions (logins, attestations, rewards) without exposing data
+
+Unlock rewards and roles for verified Uname holders
+
+
+Technical
+
+Architecture
+
+Union: Cross-chain interoperability
+
+Uname: Identity system on Union
+
+Soundness Layer: zk validation + secure data flow
+
+
+Features
+
+1. Link Uname to Soundness
+
+
+2. zk proof validation of actions
+
+
+3. Reward verified users
+
+
+
+Timeline
+
+PoC (2-4 weeks): Basic linking + zk validation
+
+MVP (4-8 weeks): Full identity + reward flow
+
+
+Innovation
+
+Combines Uname identity + Soundness zk proofs to create a privacy-first, cross-chain identity system.
+
+Contact
+
+Discord: @kikachukwuclarence
+X: @kikachukwuc
+Updates shared via GitHub, Discord, and X.


### PR DESCRIPTION
Proposal details:
- Category: identity
- Project: Uname-Soundness Identity Bridge
- Author: Kikachukwu Clarence (@KikachukwuClarence)
- Discord: kikachukwuclarence
- X/Twitter: @kikachukwuc

Summary:
This proposal integrates Union’s Uname (universal Web3 identity) with Soundness Layer’s zk-based verification. It creates a privacy-preserving identity bridge where users can verify ownership of their uname through zero-knowledge proofs without exposing wallet details. This expands interoperability and provides a foundation for reputation, authentication, and cross-chain identity.

Updates about the development will be shared via X (@kikachukwuc).