### PR TITLE
Private Transfer and Claim Transfer Private

### DIFF
--- a/submissions/infrastructure/Private Transfer and Claim Transfer Private.md
+++ b/submissions/infrastructure/Private Transfer and Claim Transfer Private.md
@@ -1,0 +1,71 @@
+# vApp Submission: Private Transfer and Claim Transfer Private
+
+## Verification
+```yaml
+github_username: "michel_stevan"
+discord_id: "844823929561546772"
+timestamp: "2025-01-15"
+```
+
+## Developer
+- **Name**: Michel Stevan
+- **GitHub**: @michel_stevan
+- **Discord**: michel_stevan
+- **Experience**: Brief background
+
+## Project
+
+### Name & Category
+- **Project**: Private Transfer and Claim Transfer Private
+- **Category**: infrastructure
+
+### Description
+A private transfer where neither the sender’s nor the recipient’s identity is visible on the explorer, and the recipient must manually claim the transfer. The sender must first encrypt their public balance.
+
+### SL Integration  
+How It Works:
+1. Public Balance ⇒ Encrypted Balance
+2. Encrypted Balance ⇒ Encrypted Transfer to Recipient
+3. Recipient ⇒ Claims the Private Transfer
+
+## Technical
+
+### Architecture
+High Hidden Balance Private Transfer
+
+### Stack
+- **Frontend**: etc
+- **Backend**: Python
+- **Blockchain**: others
+- **Storage**: etc
+
+### Features
+1. Converts Public Balance into Encrypted Balance and transfers it privately.
+2. More secure transactions, where the amount sent is hidden from everyone except the recipient.
+
+## Timeline
+
+### PoC (2-4 weeks)
+- [ ] Basic functionality
+- [x] SL integration
+- [x] Simple UI
+
+### MVP (4-8 weeks)  
+- [x] Full features
+- [ ] Production ready
+- [ ] User testing
+
+## Innovation
+1. Hides the sender and recipient identities
+2. Keeps the transaction amount fully encrypted
+3. Requires only the recipient to claim the funds, ensuring that even passive observers cannot link transactions
+
+## Contact
+Discord : michel_stevan
+
+
+**Checklist before submitting:**
+- [x] All fields completed
+- [x] GitHub username matches PR author  
+- [x] SL integration explained
+- [x] Timeline is realistic


### PR DESCRIPTION
A private transfer where neither the sender’s nor the recipient’s identity is visible on the explorer, and the recipient must manually claim the transfer. The sender must first encrypt their public balance.