### PR TITLE
Add PoE Badge vApp submission (Proof-of-Engagement Credential)

### DIFF
--- a/submissions/community/debiadi-poe-badge.md
+++ b/submissions/community/debiadi-poe-badge.md
@@ -1,0 +1,11 @@
+github_username: debiadiandika99
+discord_id: 1150277364761239583
+project name: PoE Badge – Community Engagement Credential
+category: community
+timestamp: 2025-09-09
+summary: PoE Badge rewards users who actively participate in community discussions, events, or collaborations.
+It acts as an on-chain proof of contribution and recognition for engagement.
+what it does: Verifies user engagement (e.g., Discord activity, contribution logs), Issues a non-transferable badge to the user’s wallet, Provides reference links (e.g., logs, timestamps) for verification.
+Why it matters: Encourages healthy community participation and provides verifiable recognition for contributions.
+It helps build stronger, more engaged communities with transparent contribution tracking.
+Minimal Flow: User engages in a community event or discussion, Proof of engagement is logged (message ID, event participation), Badge is minted and linked to the user’s wallet.

--- a/submissions/gaming/debiadi.md
+++ b/submissions/gaming/debiadi.md
@@ -1,0 +1,6 @@
+github_username: debiadiandika99
+discord_id: 1150277364761239583
+project name: 8Queens
+category: gaming
+timestamp: 2025-08-31
+txhash: ERBQjWP3fqhLTgnK2jpXS1adUCH6XrJ9J6aJN1JfYU8d


### PR DESCRIPTION
## PoE Badge – Community Engagement Credential

This PR adds the **PoE Badge (Proof-of-Engagement Credential)** submission under the `community` category.  

### Summary
The PoE Badge rewards users who actively participate in community discussions, events, or collaborations.  
It acts as an on-chain proof of contribution and recognition for engagement.

### What it does
- Verifies user engagement (e.g., Discord activity, contribution logs).  
- Issues a non-transferable badge to the user’s wallet.  
- Provides reference links (e.g., logs, timestamps) for verification.  

### Why it matters
Encourages healthy community participation and provides verifiable recognition for contributions.  
It helps build stronger, more engaged communities with transparent contribution tracking.  

### Minimal Flow
1. User engages in a community event or discussion.  
2. Proof of engagement is logged (message ID, event participation).  
3. Badge is minted and linked to the user’s wallet.  