### PR TITLE
Add Music Voting dApp proposal

### DIFF
--- a/submissions/social/renglut.md
+++ b/submissions/social/renglut.md
@@ -1,0 +1,38 @@
+# 🎶 Music Voting dApp
+
+## Description
+A decentralized voting application built on top of the **Soundness Layer**.  
+Users can vote for their favorite music tracks, and each vote is recorded with a Soundness proof to ensure transparency and immutability.
+
+## Category
+Social
+
+## Features
+- Connect wallet to participate in voting  
+- Transparent voting results visible to everyone  
+- Each vote proof stored via Soundness CLI  
+- Real-time voting results dashboard  
+
+## Technology
+- Frontend: React + Tailwind  
+- Backend: Node.js  
+- Smart contract (Solidity)  
+- Soundness CLI integration  
+
+## Architecture
+1. User → UI (React) → Smart Contract Voting  
+2. Smart Contract → Generate Proof via Soundness CLI  
+3. Proof → Stored on Soundness Layer  
+4. Dashboard → Displays real-time results  
+
+## Timeline
+- Week 1: Project setup & simple smart contract  
+- Week 2: Integration with Soundness CLI  
+- Week 3: UI/UX development for voting dashboard  
+- Week 4: Testing & deployment on testnet  
+
+## GitHub
+[renglut/testnet-vapps](https://github.com/renglut/testnet-vapps)
+
+## Discord 
+@renglut


### PR DESCRIPTION
This PR adds a proposal for a new vApp idea under the Social category.
The project is called Music Voting dApp, a decentralized application where users can vote for their favorite music tracks. Each vote generates a Soundness proof to ensure transparency and immutability.

Key points:

Category: Social

File added: submissions/social/renglut.md

Features: wallet connection, transparent voting, Soundness CLI proof integration, real-time dashboard

Technologies: React, Tailwind, Node.js, Solidity, Soundness CLI

Discord: @renglut