### PR TITLE
Add GreenProof Micro-Grants submission by slaranium

### DIFF
--- a/submissions/defi/slaranium.md
+++ b/submissions/defi/slaranium.md
@@ -1,0 +1,53 @@
+# GreenProof Micro-Grants
+
+**Category:** defi  
+**Contact:** Discord: @slaranium | Email: haloslaranium@gmail.com  
+
+## Summary  
+GreenProof is a vApp designed to make small-scale sustainability grants transparent, verifiable, and privacy-preserving. Funds are only released when the Soundness Layer produces a valid attestation proving that the grantee has reached agreed impact thresholds—without exposing raw data such as photos, receipts, or sensor readings.
+
+## Problem  
+Grassroots sustainability projects—community recycling programs, rural solar initiatives, or eco-tourism sites—often struggle to prove their impact to donors. Manual reporting is prone to manipulation, adds administrative burden, and compromises privacy. Donors, regulators, and communities need a trustworthy way to verify outcomes without forcing recipients to over-share sensitive information.
+
+## Solution  
+GreenProof leverages zero-knowledge proofs (ZKPs) and Soundness Layer attestations to bridge real-world data and on-chain accountability:
+
+- **Recipients** upload supporting evidence (photos, IoT data, receipts).  
+- **Client SDK** processes the data locally, generating commitments and ZK proofs.  
+- **Walrus** stores encrypted blobs and metadata.  
+- **Soundness Layer** verifies the proofs and issues an **attestation** (hash + impact score).  
+- **Sui smart contract** (`GreenProofGrants`) checks the attestation and releases funds only if thresholds are met.  
+- **Auditors and the public** can review attestations and scores on-chain without accessing sensitive raw data.
+
+## Architecture  
+- **Client SDK**: lightweight Rust/TypeScript library for commitments and proof generation.  
+- **ZK Circuits**:  
+  - `zk-impact-threshold` — prove that sensor values exceed required thresholds.  
+  - `zk-receipt-consistency` — prove that receipts align with funding claims without exposing itemized details.  
+  - `zk-geo-window` (optional) — prove that activity occurred within a designated area without revealing exact coordinates.  
+- **Walrus DA**: stores encrypted blobs and commitments.  
+- **Soundness Verifier**: endpoint to validate proofs and produce attestations.  
+- **Sui Contract**: `GreenProofGrants.move` validates attestations and manages fund release.  
+- **Auditor Dashboard**: lightweight interface to explore attestations and impact scores.
+
+## User Flow  
+1. Grantee uploads evidence (photos, sensor outputs, digital receipts).  
+2. Local client creates commitments and ZK proofs.  
+3. Encrypted blobs are stored in Walrus; proofs are submitted to the Soundness Layer.  
+4. Soundness Layer verifies proofs and issues attestations.  
+5. The Sui contract checks the attestation and releases the grant if valid.  
+6. Auditors and the public can view attestations and scores on-chain.
+
+## Development Roadmap  
+- **Weeks 1–2**: Circuit design + prototype SDK (commitment and proof generation).  
+- **Week 3**: Integrate with Soundness Layer (proof submission → attestation flow).  
+- **Week 4**: Develop Sui smart contract (`GreenProofGrants`) and deploy demo on testnet.  
+- **Week 5**: Build auditor dashboard + write documentation and tutorials.
+
+## Risks & Mitigation  
+- **Data spoofing**: mitigate through multi-evidence requirements (e.g., photo + receipt + sensor) and timestamp signatures.  
+- **Privacy leakage**: only attestations and impact scores are published; raw evidence remains encrypted.  
+- **Contextual flexibility**: thresholds and criteria are configurable per project or region.
+
+## Team  
+Currently proposed by an individual contributor (@slaranium). For implementation, the project could partner with environmental NGOs, universities, or grantmaking institutions interested in piloting verifiable and privacy-preserving funding distribution.


### PR DESCRIPTION
This PR adds the GreenProof Micro-Grants vApp proposal under submissions/defi/slaranium.md.

Proposal Summary:
- Category: defi
- Contact: haloslaranium@gmail.com
- Goal: Use ZK proofs + Soundness Layer attestations to make small-scale sustainability grants transparent, verifiable, and privacy-preserving.
